### PR TITLE
Omero 5.3.0 compatibility

### DIFF
--- a/interfaces/ROITweak.m
+++ b/interfaces/ROITweak.m
@@ -1071,11 +1071,7 @@ imageId = getappdata(handles.ROITweak, 'imageId');
 roiShapes = getappdata(handles.ROITweak, 'roiShapes');
 roiResult = roiService.findByImage(imageId, []);
 rois = roiResult.rois;
-
-if ~isjava(iUpdate)
-    iUpdate = session.getUpdateService;
-end
-
+iUpdate = session.getUpdateService; %The global variable was throwing issues, when saving and Returning ROIs:Needs to be checked
 
 for thisROI = ROIsToUpdate
     numShapes = roiShapes{thisROI}.numShapes;
@@ -1096,17 +1092,11 @@ for thisROI = ROIsToUpdate
         else
             %             mtShape = roiShapes{thisROI}.(['shape' num2str(thisShape)]);
             %             shapeType = mtShape.shapeType;
-            shapeId = mtShape.getId.getValue;
-            dbShape = qService.findAllByQuery(['select shape from Shape as s where s.id = ' num2str(shapeId)], []);
-            
-            if strcmpi(shapeType, 'class omero.model.RectangleI')
-                dbShape.setX(mtShape.getX);
-                dbShape.setY(mtShape.getY);
-            else
-                dbShape.setCx(mtShape.getCx);
-                dbShape.setCy(mtShape.getCy);
-            end
-            
+%             shapeId = mtShape.getId.getValue;
+%             dbShape = qService.findAllByQuery(['select shape from Shape as s where s.id = ' num2str(shapeId)], []);
+
+            dbShape.setX(mtShape.getX);
+            dbShape.setY(mtShape.getY);
             roiShapes{thisROI}.(['shape' num2str(thisShape)]) = iUpdate.saveAndReturnObject(dbShape);
         end
     end


### PR DESCRIPTION
Still trying to understand the workflow for running m-tools from source code, 
@mporter-gre : Here's a snippet of my workflow, please correct me if am going wrong somewhere:

` 
cd('/Users/bramalingam/OME/mtools');
addpath(genpath(pwd));
addpath(genpath('/Users/bramalingam/Downloads/OMERO.matlab-5.3.0-m9-307-1fc4dfc-ice36-b600'));
loadOmero;
ImageAnalysisLogin`

Please let me know if the fixes make sense, and if I should be looking into other parts of the code as well. Tested a few parts of the tool: "Box-it and ROI-Tweak" and did not find any connection issues when I used the latest matlab toolbox (5.3.0-m9*) from the "CI" server. 
